### PR TITLE
disable upx to avoid win10 virus detection

### DIFF
--- a/wails.json
+++ b/wails.json
@@ -6,6 +6,9 @@
   "frontend:build": "npm run build",
   "frontend:dev:watcher": "npm run dev",
   "frontend:dev:serverUrl": "auto",
+  "build": {
+    "upx": false
+  },
   "author": {
     "name": "Matcha",
     "email": "admin@mcc.wiki"


### PR DESCRIPTION
current exe bundle will be reported by win10 virus detection.
the fix is suggested by chatgpt, not verified.
![Snipaste_2024-08-24_22-29-07](https://github.com/user-attachments/assets/690773ff-0e30-4faa-9f39-7483a557fd1b)
