### PR TITLE
fix(loginfo): AccessToken获取失败的临时修复方案

### DIFF
--- a/app.go
+++ b/app.go
@@ -37,6 +37,10 @@ func (a *App) GetLogInfo() model.LogInfo {
 	return info
 }
 
+func (a *App) SetLogInfo(info model.LogInfo) {
+	config.UpdateRuntimeLogInfo(info)
+}
+
 func (a *App) GetUserList() []string {
 	userList, err := logic.GetUserList()
 	if err != nil {

--- a/config/init.go
+++ b/config/init.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"gf2gacha/logger"
+	"gf2gacha/model"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 )
@@ -81,4 +82,30 @@ func GetLayout() int64 {
 func SetLayout(layoutType int64) error {
 	viper.Set("layout", layoutType)
 	return viper.WriteConfig()
+}
+
+// 临时的LogInfo，主要用于存储用户上传的AccessToken
+
+var (
+	runtimeLogInfo model.LogInfo
+)
+
+func GetRuntimeLogInfo() model.LogInfo {
+	return runtimeLogInfo
+}
+
+func UpdateRuntimeLogInfo(logInfo model.LogInfo) {
+	if logInfo.AccessToken != "" {
+		runtimeLogInfo.AccessToken = logInfo.AccessToken
+	}
+}
+
+func FillLogInfoDefaults(in model.LogInfo) model.LogInfo {
+	result := in
+
+	if result.AccessToken == "" {
+		result.AccessToken = runtimeLogInfo.AccessToken
+	}
+
+	return result
 }

--- a/frontend/wailsjs/go/main/App.d.ts
+++ b/frontend/wailsjs/go/main/App.d.ts
@@ -38,6 +38,8 @@ export function SaveSettingFont(arg1:string):Promise<void>;
 
 export function SaveSettingLayout(arg1:number):Promise<void>;
 
+export function SetLogInfo(arg1:model.LogInfo):Promise<void>;
+
 export function UpdatePoolInfo(arg1:boolean):Promise<Array<string>>;
 
 export function UpdateTo(arg1:string):Promise<string>;

--- a/frontend/wailsjs/go/main/App.js
+++ b/frontend/wailsjs/go/main/App.js
@@ -74,6 +74,10 @@ export function SaveSettingLayout(arg1) {
   return window['go']['main']['App']['SaveSettingLayout'](arg1);
 }
 
+export function SetLogInfo(arg1) {
+  return window['go']['main']['App']['SetLogInfo'](arg1);
+}
+
 export function UpdatePoolInfo(arg1) {
   return window['go']['main']['App']['UpdatePoolInfo'](arg1);
 }

--- a/logic/GetCommunityExchangeList.go
+++ b/logic/GetCommunityExchangeList.go
@@ -13,6 +13,9 @@ func GetCommunityExchangeList() ([]model.CommunityExchangeList, error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	if logInfo.AccessToken == "" {
+		return nil, errors.New("Access Token不存在")
+	}
 
 	webToken, err := request.CommunityLogin(logInfo.AccessToken)
 	if err != nil {

--- a/logic/HandleCommunityTasks.go
+++ b/logic/HandleCommunityTasks.go
@@ -16,6 +16,9 @@ func HandleCommunityTasks() (messageList []string, err error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	if logInfo.AccessToken == "" {
+		return nil, errors.New("Access Token不存在")
+	}
 
 	webToken, err := request.CommunityLogin(logInfo.AccessToken)
 	if err != nil {

--- a/logic/UpdatePoolInfo.go
+++ b/logic/UpdatePoolInfo.go
@@ -15,6 +15,9 @@ func UpdatePoolInfo(isFull bool) (messageList []string, err error) {
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	if logInfo.AccessToken == "" {
+		return nil, errors.New("Access Token不存在")
+	}
 
 	messageList = append(messageList, logInfo.Uid)
 	for _, poolTypeUnit := range preload.PoolTypeMap {

--- a/util/GetBinLogInfo.go
+++ b/util/GetBinLogInfo.go
@@ -1,0 +1,154 @@
+package util
+
+import (
+	"compress/gzip"
+	"fmt"
+	"gf2gacha/model"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+	"unicode/utf16"
+)
+
+// GetBinLogInfo 我们可能从binlog中获取到 抽卡记录链接 和 用户UID，AccessToken暂不知抓包外的获取手段
+func GetBinLogInfo() (logInfo model.LogInfo, err error) {
+	gameDataDir, err := GetGameDataDir()
+	if err != nil {
+		return model.LogInfo{}, err
+	}
+	parentDir := filepath.Dir(gameDataDir)
+	logDir := filepath.Join(parentDir, "Log")
+	lastBin, err := findLatestLastBin(logDir)
+	if err != nil {
+		return model.LogInfo{}, err
+	}
+
+	dst := "binlog_unpacked.tmp" // 解压后的原始文件
+
+	// 解压 GZIP 文件
+	err = decompressGzip(lastBin, dst)
+	if err != nil {
+		return model.LogInfo{}, err
+	}
+
+	// 读取并解析 UTF-16LE
+	content, err := os.ReadFile(dst)
+	if err != nil {
+		return model.LogInfo{}, err
+	}
+
+	text := tryUTF16LE(content)
+
+	gachaUrl, err := extractGachaUrl(text)
+	logInfo.GachaUrl = gachaUrl
+
+	uid, err := extractGF2UID(text)
+	logInfo.Uid = uid
+
+	os.Remove(dst)
+
+	return logInfo, nil
+}
+
+func findLatestLastBin(dir string) (string, error) {
+	var latestPath string
+	var latestModTime time.Time
+
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+
+		if strings.HasSuffix(info.Name(), "last.bin") {
+			if latestPath == "" || info.ModTime().After(latestModTime) {
+				latestPath = path
+				latestModTime = info.ModTime()
+			}
+		}
+		return nil
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	if latestPath == "" {
+		return "", fmt.Errorf("未找到任何 last.bin 文件")
+	}
+
+	return latestPath, nil
+}
+
+func extractGachaUrl(text string) (string, error) {
+	re, err := regexp.Compile(`"gacha_record_url":"(.*?)"`)
+	if err != nil {
+		return "", err
+	}
+
+	matches := re.FindAllStringSubmatch(text, -1)
+	if len(matches) == 0 {
+		return "", fmt.Errorf("未在BinLog文件中找到 gacha_record_url")
+	}
+
+	last := matches[len(matches)-1]
+	if len(last) > 1 {
+		return last[1], nil
+	}
+	return "", fmt.Errorf("未在BinLog文件中找到 gacha_record_url")
+}
+
+func extractGF2UID(text string) (string, error) {
+	re, err := regexp.Compile(`Key:\s*GF2UID\s*,\s*Value:\s*(\d+)`)
+	if err != nil {
+		return "", err
+	}
+
+	matches := re.FindAllStringSubmatch(text, -1)
+	if len(matches) == 0 {
+		return "", fmt.Errorf("未找到 GF2UID")
+	}
+
+	last := matches[len(matches)-1]
+	if len(last) > 1 {
+		return last[1], nil
+	}
+
+	return "", fmt.Errorf("未找到 GF2UID")
+}
+
+func decompressGzip(src string, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	gzr, err := gzip.NewReader(in)
+	if err != nil {
+		return err
+	}
+	defer gzr.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, gzr)
+	return err
+}
+
+func tryUTF16LE(b []byte) string {
+	if len(b)%2 != 0 {
+		b = b[:len(b)-1]
+	}
+	u16 := make([]uint16, len(b)/2)
+	for i := 0; i < len(u16); i++ {
+		u16[i] = uint16(b[2*i]) | uint16(b[2*i+1])<<8
+	}
+	return string(utf16.Decode(u16))
+}

--- a/util/GetLogInfo.go
+++ b/util/GetLogInfo.go
@@ -1,6 +1,8 @@
 package util
 
 import (
+	"gf2gacha/config"
+	"gf2gacha/logger"
 	"gf2gacha/model"
 	"github.com/pkg/errors"
 	"os"
@@ -31,36 +33,51 @@ func GetLogInfo() (logInfo model.LogInfo, err error) {
 		return model.LogInfo{}, errors.New("未在日志中找到游戏路径")
 	}
 
-	regexpUserInfo, err := regexp.Compile(`"access_token":"(.+?)".+"uid":(\d+)`)
+	binLogInfo, err := GetBinLogInfo()
 	if err != nil {
 		return model.LogInfo{}, errors.WithStack(err)
 	}
-	resultUserInfoList := regexpUserInfo.FindAllSubmatch(logData, -1)
-	if len(resultUserInfoList) == 0 {
-		return model.LogInfo{}, errors.New("未在日志中找到AccessToken或Uid,可能是最近一次游戏启动时未登录")
-	}
-	resultUserInfo := resultUserInfoList[len(resultUserInfoList)-1]
-	if len(resultUserInfo) == 3 {
-		logInfo.AccessToken = string(resultUserInfo[1])
-		logInfo.Uid = string(resultUserInfo[2])
+	logInfo.GachaUrl = binLogInfo.GachaUrl
+	logInfo.Uid = binLogInfo.Uid
+
+	// 尝试从用户提交的信息中获取AccessToken
+	if config.GetRuntimeLogInfo().AccessToken != "" {
+		logInfo.AccessToken = config.GetRuntimeLogInfo().AccessToken
 	} else {
-		return model.LogInfo{}, errors.New("未在日志中找到AccessToken或Uid,可能是最近一次游戏启动时未登录")
+		logger.Logger.Warnln("获取AccessToken失败，用户没有填写这一字段")
 	}
 
-	regexpGachaUrl, err := regexp.Compile(`"gacha_record_url":"(.*?)"`)
-	if err != nil {
-		return model.LogInfo{}, errors.WithStack(err)
-	}
-	resultGachaUrlList := regexpGachaUrl.FindAllSubmatch(logData, -1)
-	if len(resultGachaUrlList) == 0 {
-		return model.LogInfo{}, errors.New("未在日志中找到抽卡链接")
-	}
-	resultGachaUrl := resultGachaUrlList[len(resultGachaUrlList)-1]
-	if len(resultGachaUrl) == 2 {
-		logInfo.GachaUrl = string(resultGachaUrl[1])
-	} else {
-		return model.LogInfo{}, errors.New("未在日志中找到抽卡链接")
-	}
+	// 以下逻辑目前无效
+	//regexpUserInfo, err := regexp.Compile(`"access_token":"(.+?)".+"uid":(\d+)`)
+	//if err != nil {
+	//	return model.LogInfo{}, errors.WithStack(err)
+	//}
+	//resultUserInfoList := regexpUserInfo.FindAllSubmatch(logData, -1)
+	//if len(resultUserInfoList) == 0 {
+	//	return logInfo, errors.New("未在日志中找到AccessToken或Uid,可能是最近一次游戏启动时未登录")
+	//}
+	//resultUserInfo := resultUserInfoList[len(resultUserInfoList)-1]
+	//if len(resultUserInfo) == 3 {
+	//	logInfo.AccessToken = string(resultUserInfo[1])
+	//	logInfo.Uid = string(resultUserInfo[2])
+	//} else {
+	//	return logInfo, errors.New("未在日志中找到AccessToken或Uid,可能是最近一次游戏启动时未登录")
+	//}
+	//
+	//regexpGachaUrl, err := regexp.Compile(`"gacha_record_url":"(.*?)"`)
+	//if err != nil {
+	//	return logInfo, errors.WithStack(err)
+	//}
+	//resultGachaUrlList := regexpGachaUrl.FindAllSubmatch(logData, -1)
+	//if len(resultGachaUrlList) == 0 {
+	//	return model.LogInfo{}, errors.New("未在日志中找到抽卡链接")
+	//}
+	//resultGachaUrl := resultGachaUrlList[len(resultGachaUrlList)-1]
+	//if len(resultGachaUrl) == 2 {
+	//	logInfo.GachaUrl = string(resultGachaUrl[1])
+	//} else {
+	//	return logInfo, errors.New("未在日志中找到抽卡链接")
+	//}
 
 	return logInfo, nil
 }


### PR DESCRIPTION
由于原来的 AccessToken 获取方法已无法生效，本 PR 提供了一个临时的替代方案：

- 新增从 binlog（位于游戏数据目录） 提取 GachaUrl 和 UID 的逻辑
- 允许用户手动填写 AccessToken，前端 UI 已更新
- 新增临时 config 存储逻辑，并在后端接口中使用该值

希望能为后续适配更新提供一个可行的过渡方案。如有更好建议欢迎指正 🙇
